### PR TITLE
Feature/Extract calculator logic into Provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:one_rep_max_calc/service/calculator_provider.dart';
 import 'package:one_rep_max_calc/service/round_to_service.dart';
 import 'package:one_rep_max_calc/service/unit_service.dart';
 import 'package:one_rep_max_calc/ui/settings_page.dart';
@@ -27,6 +28,7 @@ void main() {
           ChangeNotifierProvider(create: (context) => RoundNotifier()),
           ChangeNotifierProvider(create: (context) => RoundValueNotifier()),
           ChangeNotifierProvider(create: (context) => FormulaNotifier()),
+          ChangeNotifierProvider(create: (context) => CalculatorProvider()),
         ],
         child: const MyApp(),
       ),

--- a/lib/service/calculator_provider.dart
+++ b/lib/service/calculator_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:one_rep_max_calc/service/formula_service.dart';
+
+class CalculatorProvider with ChangeNotifier {
+  String _estimatedMax = "1RM";
+  String get estimatedMax => _estimatedMax;
+
+  void calculate(double weight, int reps, Formula formula, bool shouldRound, double roundValue) {
+    // Calls the base math from your formula_service.dart
+    double max = calculate1RM(weight, reps, formula);
+
+    // Logic extracted from home_page.dart
+    if (shouldRound) {
+      max = _roundToNearest(max, roundValue);
+    }
+
+    // String formatting extracted from home_page.dart
+    var maxString = max.toString();
+    var maxStringNum = maxString.split('.')[0];
+    var maxStringFractions = maxString.split('.')[1].substring(0, 1);
+
+    _estimatedMax = '$maxStringNum.$maxStringFractions';
+    notifyListeners();
+  }
+
+  void reset() {
+    _estimatedMax = "1RM";
+    notifyListeners();
+  }
+
+  // Helper pulled directly out of home_page.dart
+  double _roundToNearest(double num, double roundFactor) {
+    var roundTo = 1 / roundFactor;
+    return (num * roundTo).round() / roundTo;
+  }
+}

--- a/lib/service/theme_service.dart
+++ b/lib/service/theme_service.dart
@@ -35,8 +35,8 @@ class ThemeNotifier with ChangeNotifier {
 
   //*** Dark Theme ***/
   final darkTheme = ThemeData(
-    appBarTheme:
-        const AppBarTheme(backgroundColor: Color(0xff2C363F), foregroundColor: Colors.white),
+    useMaterial3: true,
+    appBarTheme: const AppBarTheme(backgroundColor: Color(0xff2C363F), foregroundColor: Colors.white),
     primaryColor: Colors.black,
     brightness: Brightness.dark,
     dividerColor: Colors.black12,
@@ -52,6 +52,7 @@ class ThemeNotifier with ChangeNotifier {
 
   //*** Light Theme ***/
   final lightTheme = ThemeData(
+    useMaterial3: true,
     appBarTheme: const AppBarTheme(backgroundColor: appBarColor, foregroundColor: Colors.white),
     primaryColor: Colors.white,
     brightness: Brightness.light,

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -5,8 +5,9 @@ import 'package:one_rep_max_calc/service/theme_service.dart';
 import 'package:one_rep_max_calc/service/unit_service.dart';
 import 'package:provider/provider.dart';
 import 'package:in_app_update/in_app_update.dart';
-import 'package:wakelock/wakelock.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
+import '../service/calculator_provider.dart';
 import '../service/utils.dart';
 import '../service/round_to_service.dart';
 
@@ -26,14 +27,9 @@ class _MyHomePageState extends State<MyHomePage> {
   String res = "1RM";
 
   @override
-  void setState(VoidCallback fn) {
-    super.setState(fn);
-  }
-
-  @override
   void initState() {
     super.initState();
-    Wakelock.enable();
+    WakelockPlus.enable();
     if (!kDebugMode) {
       checkForUpdate();
     }
@@ -54,8 +50,11 @@ class _MyHomePageState extends State<MyHomePage> {
     var flexSpacebetween = 1;
     var flexTextFeild = 3;
 
-    return Consumer5<ThemeNotifier, RoundNotifier, RoundValueNotifier, UnitNotifier, FormulaNotifier>(
-        builder: (context, theme, roundWeightStatus, roundWeightValue, unitProvider, formulaProvider, child) => Center(
+    return Consumer6<ThemeNotifier, RoundNotifier, RoundValueNotifier, UnitNotifier, FormulaNotifier,
+            CalculatorProvider>(
+        builder: (context, theme, roundWeightStatus, roundWeightValue, unitProvider, formulaProvider,
+                calculatorProvider, child) =>
+            Center(
               child: Scaffold(
                 resizeToAvoidBottomInset: false,
                 appBar: AppBar(
@@ -66,9 +65,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       tooltip: 'Settings',
                       onPressed: () {
                         Navigator.pushNamed(context, '/settings').then((value) {
-                          setState(() {
-                            res = '1RM';
-                          });
+                          calculatorProvider.reset();
                           FocusManager.instance.primaryFocus?.unfocus();
                         });
                         weight.clear();
@@ -155,21 +152,19 @@ class _MyHomePageState extends State<MyHomePage> {
                               if (_formKey.currentState!.validate()) {
                                 var weightValue = double.parse(weight.text);
                                 var repsValue = int.parse(reps.text);
+
+                                // Keep the UI logic (SnackBar) in the UI
                                 if (repsValue > 6) {
                                   printSnackBar("Calculations are more accurate in 1-6 rep range", context);
                                 }
 
-                                double max = calculate1RM(weightValue, repsValue, formulaProvider.formula!);
-
-                                if (roundWeightStatus.getRoundStatus()) {
-                                  var roundValue = roundWeightValue.getRoundValue();
-                                  max = roundToNearest(max, roundValue);
-                                }
-
-                                var maxString = max.toString();
-                                var maxStringNum = maxString.split('.')[0];
-                                var maxStringFractions = maxString.split('.')[1].substring(0, 1);
-                                res = '$maxStringNum.$maxStringFractions';
+                                // Send the math to the logic layer
+                                Provider.of<CalculatorProvider>(context, listen: false).calculate(
+                                    weightValue,
+                                    repsValue,
+                                    formulaProvider.formula!,
+                                    roundWeightStatus.getRoundStatus(),
+                                    roundWeightValue.getRoundValue());
                               }
                             },
                             child: const Padding(
@@ -181,7 +176,9 @@ class _MyHomePageState extends State<MyHomePage> {
                             )),
                         SizedBox(height: height3 * 0.075),
                         Text(
-                          res == '1RM' ? res : '$res ${unitProvider.unit}',
+                          calculatorProvider.estimatedMax == '1RM'
+                              ? calculatorProvider.estimatedMax
+                              : '${calculatorProvider.estimatedMax} ${unitProvider.unit}',
                           style: Theme.of(context).textTheme.titleMedium?.copyWith(fontSize: 48),
                         ),
                       ],
@@ -204,12 +201,6 @@ class _MyHomePageState extends State<MyHomePage> {
       return 'Missing value';
     }
     return null;
-  }
-
-  double roundToNearest(double num, double roundFactor) {
-    var roundTo = 1 / roundFactor;
-    var val = (num * roundTo).round() / roundTo;
-    return val;
   }
 
   Future<void> checkForUpdate() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,26 +6,27 @@ publish_to: 'none'
 version: 4.1.0+6
 
 environment:
-  sdk: '>=2.18.5 <3.0.0'
-  flutter: '3.10.1'
+  sdk: '^3.2.0' # Welcome to Dart 3. Do not go back.
 
 dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.6
   settings_ui: ^2.0.2
-  shared_preferences: ^2.0.15
-  provider: ^6.0.4
-  flutter_launcher_icons: ^0.13.1
-  in_app_update: ^4.0.1
-  wakelock: ^0.6.2
+  shared_preferences: ^2.2.2
+  provider: ^6.1.1
+  flutter_launcher_icons: ^0.14.4
+  in_app_update: ^4.2.3
+  wakelock_plus: ^1.2.8 
+  in_app_review: ^2.0.8
+
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^6.0.0 
 
-  flutter_lints: ^2.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Introduce CalculatorProvider to encapsulate 1RM calculation, rounding and formatting (new lib/service/calculator_provider.dart) and wire it into the app (main.dart). Update home_page.dart to use the provider (Consumer6) — remove local result state, move calculation and rounding logic to the provider, keep UI concerns (SnackBar) in the widget, and use WakelockPlus. Enable Material3 in theme_service.dart. Bump Dart SDK and dependencies in pubspec.yaml (dependency upgrades, replace wakelock with wakelock_plus, add in_app_review, upgrade flutter_lints).